### PR TITLE
Removing `qiskit-terra` dependency in favor of `qiskit`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ncon
-qiskit-aer==0.11.2
-qiskit-terra>=0.25.1
+qiskit-aer==0.11
+qiskit>=0.44, <1
 quimb
 tensornetwork
 tensorflow


### PR DESCRIPTION
Fixes #2

Details:
 * `qiskit-terra>=0.25` is equivalent to `qiskit>=0.44`
 * removing the patch version pin for `qiskit-aer` and `qiskit` (so bug fixing can land)
 * adding a cap to avoid transitioning to `qiskit 1` until the code gets ready for it.